### PR TITLE
Add forceDelete option, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,18 @@ Type: `boolean`
 Default: `false`
 
 Set to `true` if you need to `pipe()` the files to another gulp plugin.
+
 When set to false nothing will get emitted to the stream.
+
+### forceDelete
+Type: `boolean`
+
+Default: `false`
+
+Set to `true` if you want to force delete files in your directory. This option remove error
+```
+Cannot delete files/folders outside the current working directory. Can be overriden with the `force` option.
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function (revManifestFile, options) {
         keepRenamedFiles: true,
         keepManifestFile: true,
         emitChunks: false,
+        forceDelete: false,
         ...options
     };
     try {
@@ -61,7 +62,7 @@ module.exports = function (revManifestFile, options) {
             return cb();
         },
         (cb) => {
-            del.sync(filesToDel);
+            del.sync(filesToDel, { force: options.forceDelete });
             return cb();
         }
     );


### PR DESCRIPTION
Hi, i added option forceDelete for del module. I use it in private project and will hasn't publish it in npmjs. Can you add this feature to your plugin?