### PR TITLE
Add delOptions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,14 @@ Default: `false`
 Set to `true` if you need to `pipe()` the files to another gulp plugin.
 When set to false nothing will get emitted to the stream.
 
+### delOptions
+Type: `object`
+
+Default: `{}`
+
+Options to pass down to the `del` module whilst deleting files.
+See [`del` module documentation](https://www.npmjs.com/package/del#options) for the list of available options.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = function (revManifestFile, options) {
         keepRenamedFiles: true,
         keepManifestFile: true,
         emitChunks: false,
+        delOptions: {},
         ...options
     };
     try {
@@ -61,7 +62,7 @@ module.exports = function (revManifestFile, options) {
             return cb();
         },
         (cb) => {
-            del.sync(filesToDel);
+            del.sync(filesToDel, options.delOptions);
             return cb();
         }
     );

--- a/test/test.js
+++ b/test/test.js
@@ -135,5 +135,29 @@ describe('gulp-rev-dist-clean', () => {
                 )
                 .pipe(assert.end(done));
         });
+
+        it('should pass down delOptions to del module', (done) => {
+            gulp.task('process', () =>
+                gulp.src([path.join(buildPath, '**/*')], {read: false}).pipe(
+                    revDistClean(manifestFile, {
+                        keepOriginalFiles: false,
+                        delOptions: {dryRun: true}
+                    })
+                )
+            );
+            gulp.task('assert', () =>
+                gulp
+                    .src([path.join(buildPath, '**/*')], {read: false})
+                    // Nothing should be deleted
+                    // Original dirs
+                    // + original files
+                    // + revised files
+                    // + a manifest file
+                    .pipe(assert.length(countDirs + countFiles * 2 + 1))
+                    .pipe(assert.end(done))
+            );
+            gulp.task('test', gulp.series('process', 'assert'));
+            gulp.task('test')();
+        });
     });
 });


### PR DESCRIPTION
As discussed in https://github.com/alexandre-abrioux/gulp-rev-dist-clean/pull/11#issuecomment-842192055, added a new `delOptions` to pass down any of the options supported by the [`del` ](https://github.com/sindresorhus/del) module.